### PR TITLE
Add Airflow DAGs for cleaning and loading Snowflake dataAdded DAGs for cleaning and loading cleaned data to Snowflake

### DIFF
--- a/dags/clean_and_upload_all_files.py
+++ b/dags/clean_and_upload_all_files.py
@@ -1,0 +1,109 @@
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from datetime import datetime
+import pandas as pd
+import os
+import subprocess
+
+default_args = {
+    'owner': 'aditya',
+    'start_date': datetime(2024, 1, 1),
+    'retries': 1,
+}
+
+dag = DAG(
+    'clean_and_upload_all_files',
+    default_args=default_args,
+    schedule='@daily',
+    catchup=False,
+    tags=['snowflake', 'cleaning', 'etl']
+)
+
+HOME = os.path.expanduser('~')
+STAGE_FQ = '@FINANCE_PROJECT.ANALYTICS.MY_STAGE'
+
+files_specs = [
+    {
+        'unclean': 'bank_customer_churn_unclean.csv',
+        'cleaned': 'bank_customer_churn_cleaned.csv',
+        'type': 'churn',
+    },
+    {
+        'unclean': 'uci_credit_default_unclean.csv',
+        'cleaned': 'uci_credit_default_cleaned.csv',
+        'type': 'credit_default',
+    },
+    {
+        'unclean': 'personal_loan_modeling_unclean.csv',
+        'cleaned': 'personal_loan_modeling_cleaned.csv',
+        'type': 'personal_loan',
+    },
+]
+
+def run_cmd(cmd):
+    print(f"Running: {cmd}")
+    res = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    print(res.stdout)
+    if res.returncode != 0:
+        print("ERROR:", res.stderr)
+        res.check_returncode()
+
+def download_and_clean():
+    # download each unclean file
+    for spec in files_specs:
+        unclean = spec['unclean']
+        cleaned = spec['cleaned']
+        # GET from landing
+        run_cmd(f'snowsql -c my_connection -q "GET {STAGE_FQ}/landing/{unclean} file://{HOME}/ OVERWRITE=TRUE;"')
+
+        src = os.path.join(HOME, unclean)
+        dst = os.path.join(HOME, cleaned)
+        if not os.path.exists(src):
+            print(f"Missing downloaded file, skipping: {src}")
+            continue
+
+        df = pd.read_csv(src)
+        df.columns = df.columns.str.strip().str.lower()
+
+        if spec['type'] == 'churn':
+            required = []
+            if 'customerid' in df.columns:
+                required.append('customerid')
+            if 'customer_id' in df.columns:
+                required.append('customer_id')
+            required += ['creditscore', 'balance']
+            df.dropna(subset=required, inplace=True)
+            if 'geography' in df.columns:
+                df['geography'] = df['geography'].astype(str).str.lower().str.title()
+            if 'gender' in df.columns:
+                df['gender'] = df['gender'].astype(str).str.lower().str.title()
+        elif spec['type'] == 'credit_default':
+            df.dropna(subset=['limit_bal', 'age', 'pay_0'], inplace=True)
+        elif spec['type'] == 'personal_loan':
+            df.dropna(subset=['income', 'ccavg', 'mortgage'], inplace=True)
+
+        df.drop_duplicates(inplace=True)
+        df.to_csv(dst, index=False)
+        print(f"Cleaned {unclean} -> {cleaned} (shape: {df.shape})")
+
+def upload_cleaned():
+    # ensure cleaned folder exists implicitly by putting into it
+    for spec in files_specs:
+        cleaned = spec['cleaned']
+        path = os.path.join(HOME, cleaned)
+        if os.path.exists(path):
+            run_cmd(f'snowsql -c my_connection -q "PUT file://{path} {STAGE_FQ}/cleaned AUTO_COMPRESS=FALSE OVERWRITE=TRUE;"')
+    # list to confirm
+    run_cmd(f'snowsql -c my_connection -q "LIST {STAGE_FQ}/cleaned/"')
+
+with dag:
+    t1 = PythonOperator(
+        task_id='download_and_clean_all',
+        python_callable=download_and_clean
+    )
+    t2 = PythonOperator(
+        task_id='upload_all_cleaned',
+        python_callable=upload_cleaned
+    )
+
+    t1 >> t2

--- a/dags/load_cleaned_to_snowflake_tables.py
+++ b/dags/load_cleaned_to_snowflake_tables.py
@@ -1,0 +1,67 @@
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
+from datetime import datetime
+
+default_args = {
+    'owner': 'aditya',
+    'start_date': datetime(2024, 1, 1),
+    'retries': 1,
+}
+
+with DAG(
+    dag_id='load_cleaned_to_snowflake_tables',
+    default_args=default_args,
+    schedule='@daily',  # or change to None for only manual trigger
+    catchup=False,
+    tags=['snowflake', 'load']
+) as dag:
+
+    # 1. Pre-check that cleaned files exist
+    check_cleaned_files = BashOperator(
+        task_id='check_cleaned_files_exist',
+        bash_command="""
+        echo "Verifying cleaned files in stage..."
+        snowsql -c my_connection -q "LIST @FINANCE_PROJECT.ANALYTICS.MY_STAGE/cleaned/bank_customer_churn_cleaned.csv" || (echo "missing bank_customer_churn_cleaned.csv" && exit 1)
+        snowsql -c my_connection -q "LIST @FINANCE_PROJECT.ANALYTICS.MY_STAGE/cleaned/uci_credit_default_cleaned.csv" || (echo "missing uci_credit_default_cleaned.csv" && exit 1)
+        snowsql -c my_connection -q "LIST @FINANCE_PROJECT.ANALYTICS.MY_STAGE/cleaned/personal_loan_modeling_cleaned.csv" || (echo "missing personal_loan_modeling_cleaned.csv" && exit 1)
+        echo "All required cleaned files are present."
+        """
+    )
+
+    # 2. Load each cleaned CSV into its Snowflake table
+    load_bank_customer_churn = SnowflakeOperator(
+        task_id='load_bank_customer_churn',
+        snowflake_conn_id='snowflake_conn',
+        sql="""
+            COPY INTO FINANCE_PROJECT.ANALYTICS.BANK_CUSTOMER_CHURN
+            FROM @FINANCE_PROJECT.ANALYTICS.MY_STAGE/cleaned/bank_customer_churn_cleaned.csv
+            FILE_FORMAT = (TYPE = 'CSV' FIELD_OPTIONALLY_ENCLOSED_BY='"' SKIP_HEADER=1)
+            FORCE = TRUE;
+        """,
+    )
+
+    load_uci_credit_default = SnowflakeOperator(
+        task_id='load_uci_credit_default',
+        snowflake_conn_id='snowflake_conn',
+        sql="""
+            COPY INTO FINANCE_PROJECT.ANALYTICS.UCI_CREDIT_DEFAULT
+            FROM @FINANCE_PROJECT.ANALYTICS.MY_STAGE/cleaned/uci_credit_default_cleaned.csv
+            FILE_FORMAT = (TYPE = 'CSV' FIELD_OPTIONALLY_ENCLOSED_BY='"' SKIP_HEADER=1)
+            FORCE = TRUE;
+        """,
+    )
+
+    load_personal_loan_modeling = SnowflakeOperator(
+        task_id='load_personal_loan_modeling',
+        snowflake_conn_id='snowflake_conn',
+        sql="""
+            COPY INTO FINANCE_PROJECT.ANALYTICS.PERSONAL_LOAN_MODELING
+            FROM @FINANCE_PROJECT.ANALYTICS.MY_STAGE/cleaned/personal_loan_modeling_cleaned.csv
+            FILE_FORMAT = (TYPE = 'CSV' FIELD_OPTIONALLY_ENCLOSED_BY='"' SKIP_HEADER=1)
+            FORCE = TRUE;
+        """,
+    )
+
+    # Dependencies
+    check_cleaned_files >> [load_bank_customer_churn, load_uci_credit_default, load_personal_loan_modeling]


### PR DESCRIPTION
This PR adds two Airflow DAGs:

1. clean_and_upload_all_files.py
   - Downloads raw *_unclean.csv files from @MY_STAGE/landing/
   - Cleans each according to the specified rules (missing value drops, casing normalization, duplicate removal)
   - Uploads cleaned outputs to @MY_STAGE/cleaned/

2. load_cleaned_to_snowflake_tables.py
   - Validates presence of cleaned files in the stage
   - Loads them into the corresponding Snowflake tables using COPY INTO

These DAGs implement the end-to-end pipeline for customer churn, credit default, and personal loan modeling datasets.
